### PR TITLE
Vscode-LaTeX-Snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# OrangeX4's HyperSnips
+
+You can use it in vscode instead of vim like
+https://castel.dev/post/lecture-notes-1/#fractions
+
+Use it via vscode extension https://marketplace.visualstudio.com/items?itemName=OrangeX4.hsnips
+
+Specially, it support **math environment**! It only goes into effect in `$...$`, `$$...$$`, etc...
+
+For example:
+
+```
+(1+2)/    --->    \frac{1+2}{}
+```
+
+The snippets is adapted from https://zhuanlan.zhihu.com/p/199268436.

--- a/latex.hsnips
+++ b/latex.hsnips
@@ -134,19 +134,15 @@ snippet R+ "R0+" iAm
 R_0^+
 endsnippet
 
-snippet td "superscript" iAm
-^{${1}}$0
-endsnippet
-
 snippet pow "power" iAm
 ^{${1:2}}$0
 endsnippet
 
-snippet cb "cubic" iAm
-^{3}$0
-endsnippet
-
 # == Subscript Operation ==
+
+snippet td "subscript" iAm
+_{${1}}$0
+endsnippet
 
 snippet `([A-Za-z])(\d)` "auto subscript" wAm
 `` rv = m[1] + "_" + m[2]``
@@ -574,8 +570,30 @@ snippet bnn "bigcap" wAm
 endsnippet
 
 priority 100
-snippet `(DINT|dint)` "integral" wAm
-\int\limits_{${1:-\infty}}^{${2:\infty}} ${3} \\mathrm{d}${4:x} $0
+snippet dint "integral" wAm
+\int_{${1:-\infty}}^{${2:\infty}} ${3} ~\\mathrm{d}${4:x} $0
+endsnippet
+
+priority 200
+snippet `c(o|n)?(l|n)?(b|c)?int` "s integral" wAm
+``
+let final = "\\"; // init
+let isO = m[1] == "o";
+(isO) ? final += "o" : "" // o option
+let b = 1;
+let isL = m[2] == "l";
+(m[3] == 'b') ? b = 2 : (m[3] == 'c') ? b = 3 : 1;
+for (let i = 0; i < b - 1; i++) {
+final += "i";
+}
+final += "int";
+final += ((b >= 2) || (b != 1 && !isO && isL)) ? "\\limits" : "";
+let r = (b == 3) ? "E" : (b == 1 && (isL || isO)) ? "C" : "R";
+final += ((b >= 2) || isO || (b == 1 && isL)) ? "_{${1:" + r + "}}" : "_{${1:-\\infty}}^{${2:\\infty}}";
+let x = (b == 2) ? "A" : (b == 3) ? "V" : (b == 1 && isL) ? "s" : "x";
+final += " ${3} ~\\mathrm{d}${4:" + x + "} $0";
+rv = final;
+``
 endsnippet
 
 # Custom: Can add more defined operator
@@ -737,7 +755,6 @@ snippet `table(\d)(\d)` "create table with rows and columns" wA
 rv = createTable(m[1], m[2]);
 ``
 endsnippet
-
 
 
 

--- a/latex.hsnips
+++ b/latex.hsnips
@@ -1,0 +1,814 @@
+global
+// JavaScript code
+function gen_matrix(nrow, ncol) {
+	let results = "";
+	let order = 1;
+	for (var i=0; i<nrow; i++){
+		results += '	';
+		for(var j = 0;j <ncol-1;j++){
+			results += "$" +(order ).toString() + " & ";
+			order ++;
+		}
+		results += "$"+(order).toString() +" \\\\" + "\\ ";
+		order ++;
+	}
+	return results;
+}
+
+function tes_matrix(nrow, ncol,t) {
+	let results = "";
+	let order = 1;
+	for (var i=0; i<nrow; i++){
+		results += '	';
+		for(var j = 0;j <ncol-1;j++){
+			if (order > 1 ){
+				results += "${" +(order ).toString() + ":" + t[order-2] + "}\t & ";
+			}
+			else{
+				results += "$" +(order ).toString()  + " & ";
+			}
+			order ++;
+		}
+		results += "$"+(order).toString() +" \\\\" + "\\ ";
+		order ++;
+	}
+	return results;
+}
+
+// 输出一个表格
+function createTable(rows, cols) {
+    let ret = "";
+    for (let i = 0; i < parseInt(rows) + 2; i++) {
+        for (let j = 0; j < parseInt(cols); j++) {
+            if (i === 1) {
+                ret += "|---";
+            } else {
+                ret += "|  ";
+            }
+        }
+        ret += "|\n"
+    }
+    return ret;
+}
+
+endglobal
+
+
+# == Fraction Match ==
+
+
+snippet // "Fraction" iAm
+\frac{$1}{$2}$0
+endsnippet 
+
+snippet `((\d+)|(\d*)(\\)?([A-Za-z!]+)((\^|_)(\{\d+\}|\d))*)/` "Fraction no ()" iAm
+\frac{``rv = m[1]``}{$1}$0
+endsnippet
+
+priority 200
+snippet `(?<=\s)(\\mu|\\alpha|\\sigma|\\rho|\\beta|\\gamma|\\delta|\\zeta|\\eta|\\varepsilon|\\theta|\\iota|\\kappa|\\vartheta|\\lambda|\\nu|\\pi|\\rho|\\tau|\\upsilon|\\phi|\\chi|\\psi|\\omega|\\Gamma|\\Delta|\\Theta|\\Lambda|\\Xi|\\Pi|\\Sigma|\\Upsilon|\\Phi|\\Psi|\\Omega|[A-Za-z]{1,2})?(_[A-Za-z0-9]|_\{[^}]+\})?(\^[A-Za-z0-9]|\^\{[^}]+\})?(_[A-Za-z0-9]|_\{[^}]+\})?(\([^)]+\))(_[A-Za-z0-9]|_\{[^}]+\})?(\^[A-Za-z0-9]|\^\{[^}]+\})?(_[A-Za-z0-9]|_\{[^}]+\})?\/` "Fraction with ()" iAm
+``rv = "\\frac{" + m.slice(1, m.length).join('') + "}{$1}$2"``
+endsnippet
+
+# == Hat Operation ==
+
+# ==== Auto Capture Hat Operation ====
+snippet `(\(?)(\\?[a-zA-Z]\w*)(\)?)(hbar|BAR)` "Bar" iAm
+\overline{``rv = m[1] + m[2] + m[3]``}
+endsnippet
+
+snippet `(\\?[a-zA-Z]\w*)(htd|TD)` "tilde" iAm
+\widetilde{``rv = m[1]``}
+endsnippet
+
+snippet `(\\?[a-zA-Z]\w*)(hat|HAT)` "hat" iAm
+\hat{``rv = m[1]``}
+endsnippet
+
+snippet `(\\?[a-zA-Z]\w*)(hvec)` "Vector postfix" iAm
+\vec{``rv = m[1]``}
+endsnippet
+
+snippet `(\\?[a-zA-Z]\w*)(rta)` "Vector postfix" iAm
+\overrightarrow{``rv = m[1]``}
+endsnippet
+
+snippet `(\\?[a-zA-Z]\w*)(hdot)` "dot" iAm
+\dot{``rv = m[1]``}
+endsnippet
+
+snippet `(\\?[a-zA-Z]\w*)(hddot)` "ddot" iAm
+\ddot{``rv = m[1]``}
+endsnippet
+
+# ===== Static Hat Operation ====
+
+snippet hbar "bar" iAm
+\overline{$1}$0
+endsnippet
+
+snippet hat "hat" iAm
+\hat{$1}$0
+endsnippet
+
+snippet hsq "\sqrt{}" iAm
+\sqrt{${1}}$0
+endsnippet
+
+# == Superscript Operation ==
+
+snippet invs "inverse" wAm
+^{-1}
+endsnippet
+
+priority 10000
+snippet TR "inverse" iAm
+^{\mathsf{T}}
+endsnippet
+
+snippet CL "complement" wAm
+^{c}
+endsnippet
+
+snippet R+ "R0+" iAm
+R_0^+
+endsnippet
+
+snippet td "superscript" iAm
+^{${1}}$0
+endsnippet
+
+snippet pow "power" iAm
+^{${1:2}}$0
+endsnippet
+
+snippet cb "cubic" iAm
+^{3}$0
+endsnippet
+
+# == Subscript Operation ==
+
+snippet `([A-Za-z])(\d)` "auto subscript" wAm
+`` rv = m[1] + "_" + m[2]``
+endsnippet
+
+priority 100
+snippet `([A-Za-z])_(\d{2})` "auto subscript" wAm
+`` rv = m[1] + "_{" + m[2] + "}$0" ``
+endsnippet
+
+priority 100
+snippet `([A-Za-z])S(\d)` "auto subscript" wAm
+`` rv = m[1] + "_{" + m[2] + "$1}$2"``
+endsnippet
+
+snippet `\b(?<!\\)([A-Za-z])([a-z])\2` "auto subscript 2" iAm
+`` rv = m[1] + "_" + m[2].substring(0, 1) ``
+endsnippet
+
+snippet `\b(?<!\\)([A-Za-z])S([a-z])\2` "auto subscript 2" iAm
+`` rv = m[1] + "_{" + m[2].substring(0, 1) + "$1}$2"``
+endsnippet
+
+# Custom: Add more greek letters
+snippet `(\\mu|\\alpha|\\sigma|\\rho|\\beta|\\gamma|\\delta|\\zeta|\\eta|\\varepsilon|\\theta|\\iota|\\kappa|\\vartheta|\\lambda|\\nu|\\pi|\\rho|\\tau|\\upsilon|\\phi|\\chi|\\psi|\\omega|\\Gamma|\\Delta|\\Theta|\\Lambda|\\Xi|\\Pi|\\Sigma|\\Upsilon|\\Phi|\\Psi|\\Omega)([a-z])\2` "auto subscript for greek letter" iAm
+`` rv = m[1] + "_" + m[2].substring(0, 1) ``
+endsnippet
+
+snippet `(\\mu|\\alpha|\\sigma|\\rho|\\beta|\\gamma|\\delta|\\zeta|\\eta|\\varepsilon|\\theta|\\iota|\\kappa|\\vartheta|\\lambda|\\nu|\\pi|\\rho|\\tau|\\upsilon|\\phi|\\chi|\\psi|\\omega|\\Gamma|\\Delta|\\Theta|\\Lambda|\\Xi|\\Pi|\\Sigma|\\Upsilon|\\Phi|\\Psi|\\Omega)S([a-z])\2` "auto subscript for greek letter" iAm
+`` rv = m[1] + "_{${1:" + m[2].substring(0, 1) + "}}$2"``
+endsnippet
+
+# == Font Operation ==
+
+# ==== Static Operation ====
+
+snippet txt "text" iAm
+\text{$1}$0
+endsnippet
+
+snippet tit "text it" iAm
+\textit{$1}$0
+endsnippet
+
+snippet mcal "mathcal" im
+\mathcal{$1}$0
+endsnippet
+
+snippet mbb "mathbb" iAm
+\mathbb{$1}$0
+endsnippet
+
+snippet mbf "mathbb" iAm
+\mathbf{$1}$0
+endsnippet
+
+snippet mbf "mathbm" iAm
+\mathbf{$1}$0
+endsnippet
+
+# ==== Dynamic Operation ====
+
+priority 100
+snippet `(\\?[a-zA-Z]\w*)(bf|BF)` "mathbf" iAm
+\mathbf{``rv = m[1]``}
+endsnippet
+
+priority 100
+snippet `(\\?[a-zA-Z]\w*)(bm|BM)` "mathbm" iAm
+\bm{``rv = m[1]``}
+endsnippet
+
+priority 100
+snippet `(\\?[a-zA-Z]\w*)(bs)` "boldsymbol" iAm
+\boldsymbol{``rv = m[1]``}
+endsnippet
+
+priority 100
+snippet `(\\?[a-zA-Z]\w*)mcal` "mathcal" iAm
+\mathcal{``rv = m[1].toUpperCase() ``} $0
+endsnippet
+
+priority 100
+snippet `(?<!\\)\b([a-zA-Z]+)rm` "mathrm" iAm
+\mathrm{``rv = m[1]``}
+endsnippet
+
+priority 100
+snippet `(\\?[a-zA-Z]\w*)mbb` iAm
+\mathbb{``rv = m[1]``} $0
+endsnippet
+
+
+# == Auto Symbol ==
+
+snippet oo "\infty" wAmm
+\infty
+endsnippet
+
+snippet ... "cdots" iAm
+\cdots 
+endsnippet
+
+snippet <> "hokje" iA
+\diamond 
+endsnippet
+
+# +... -> , \cdots
+# -  ... -> , \cdots
+# add a space if there already is one.
+priority 101
+snippet `(?<=[-+])\s*\.\.\.` "smart cdots" irA
+ \cdots 
+endsnippet
+
+# It seems that \ldots is only used when , ..., 
+# ,... -> , \ldots
+# ,  ... -> , \ldots
+priority 101
+snippet `(?<=,)(\s*)\.\.\.` "smart ldots" irA
+ \ldots 
+endsnippet
+
+snippet ** "dot multiply" iAm
+\cdot 
+endsnippet
+
+snippet xx "cross" iAm
+\times 
+endsnippet
+
+snippet eps "epsilon" wAm
+\epsilon
+endsnippet
+
+snippet `(?<=\b|\d+)(?<!\\)(ell|nabla|notin)` "symbol" iAm
+\\``rv = m[1]``
+endsnippet
+
+
+snippet `(?<=\b|\d+)(?<!\\)(arcsin|arccos|arctan|arccot|arccsc|arcsec|pi|zeta|oint|iiint|iint|int)` "ln" wAm
+\\``rv = m[1]``
+endsnippet
+
+snippet `(?<=\b|\d+)(?<!\\)(sin|cos|arccot|cot|csc|ln|log|exp|star|perp)` "ln" wAm
+\\``rv = m[1]``
+endsnippet
+
+snippet `(?<=\b|\d+)(?<!\\)(mu|alpha|sigma|rho|beta|gamma|delta|zeta|eta|varepsilon|theta|iota|kappa|vartheta|lambda|nu|pi|rho|tau|upsilon|varphi|phi|chi|psi|omega|Gamma|Delta|Theta|Lambda|Xi|Pi|Sigma|Upsilon|Phi|Psi|Omega)` "greek" wAm
+\\``rv = m[1]``
+endsnippet
+
+# ==== Space Symbol ====
+snippet `(?<=\b|\d+)(?<!\\)(quad)` "ln" wAm
+\\``rv = m[1]``
+endsnippet
+
+# ==== Logic Symbol ====
+
+
+snippet -> "to" iAm
+\to 
+endsnippet
+
+snippet !> "mapsto" iAm
+\mapsto 
+endsnippet
+
+snippet vdash "vdash" iAm
+\\vdash
+endsnippet
+
+snippet => "implies" iAm
+\implies
+endsnippet
+
+snippet =< "implied by" iAm
+\impliedby
+endsnippet
+
+snippet iff "if and only if" iAm
+\iff
+endsnippet
+
+snippet EE "exist" iAm
+\exists 
+endsnippet
+
+
+snippet AA "forall" iAm
+\forall 
+endsnippet
+
+snippet bec "because" iAm
+\because 
+endsnippet
+
+snippet thr "therefore" iAm
+\therefore 
+endsnippet
+
+
+# ==== Compare Symbol ====
+
+snippet -- "setminus" iAm
+\setminus
+endsnippet
+
+snippet >= "greater than" iAm
+\geqslant $0
+endsnippet
+
+snippet dis "displaystyle" iAm
+\displaystyle 
+endsnippet
+
+snippet <= "less than" iAm
+\leqslant $0
+endsnippet
+
+snippet != "no equals" iAm
+\neq 
+endsnippet
+
+snippet == " constan equals" iAm
+\equiv 
+endsnippet
+
+snippet ~~ " Amppro equals" iAm
+\thickapprox 
+endsnippet
+
+snippet ~= " Amppro equals2" iAm
+\cong
+endsnippet
+
+snippet >> ">>" iAm
+\gg
+endsnippet
+
+
+snippet << "<<" iAm
+\ll
+endsnippet
+
+# == Auto Environment ==
+
+# ==== Auto Math Mode ====
+
+snippet im "inline Math" wA
+$${1}$$0
+endsnippet
+
+snippet im "inline Math" wA
+$${1}$``
+let str = t[0];
+let test = str.charAt(str.length - 1);
+if (test != ',' &&  test != '.' &&  test != '-' && test !='?' && test !=' '){
+	rv = ' ';
+}
+else{
+	rv = '';
+}``$2
+endsnippet
+
+snippet dm "display Math" wA
+$$
+${1}
+$$$0
+endsnippet
+
+# ==== Common Environment ====
+
+snippet case "cases" wAm
+\begin{cases}
+	$1 \\\\
+\end{cases}
+endsnippet
+
+snippet ali "aligned" wAm
+\begin{aligned}
+$1 \\\\
+\end{aligned}
+endsnippet
+
+# == Auto Adaptive Close ==
+
+snippet ceil "ceil" iAm
+\left\lceil $1 \right\rceil $0
+endsnippet
+
+snippet floor "floor" iAm
+\left\lfloor $1 \right\rfloor$0
+endsnippet
+
+priority 100
+snippet @( "left( right)" Aim
+\left( ${1} \right) $0
+endsnippet
+
+priority 100
+snippet @| "left| right|" Aim
+\left| ${1} \right| $0
+endsnippet
+
+priority 100
+snippet @{ "left\{ right\}" Aim
+\left\\{ ${1} \right\\} $0
+endsnippet
+
+priority 100
+snippet @[ "left[ right]" Aim
+\left[ ${1} \right] $0
+endsnippet
+
+priority 100
+snippet @< "leftangle rightangle" iAm
+\left<${1} \right>$0
+endsnippet
+
+snippet ( "auto close ()" iA
+(${1})
+endsnippet
+
+snippet { "auto close {}" iA
+{${1}}
+endsnippet
+
+snippet [ "auto close []" iA
+[${1}]
+endsnippet
+
+snippet norm iAm
+\left\| ${1} \right\|_{$2}$3
+endsnippet
+
+# == Snippet ==
+
+# ==== General Snippet ====
+
+# ====== Lite Snippet ======
+
+snippet tag "tag" iAm
+\tag{$1}
+endsnippet
+
+snippet xyb "Auto (x, y)" iAm
+(x, y)
+endsnippet
+
+snippet xyzb "Auto (x, y ,z)" iAm
+(x, y, z)
+endsnippet
+
+priority 100
+snippet `\b([a-zA-Z])n(\d)` "x[n+1]" iAm
+``rv = m[1]``_{${1:n}+``rv = m[2]``}$0
+endsnippet
+
+# Unkown
+snippet rij "mrij" iAm
+(${1:x}_${2:n})_{${3:$2} \\in ${4:N}}$0
+endsnippet
+
+priority 200
+snippet abs "absolute value" iAm
+\left\vert ${1} \right\vert $0
+endsnippet
+
+snippet beg "begin{} / end{}" bA
+\\begin{$1}
+	$0
+\\end{$1}
+endsnippet
+
+# ======== N Series ========
+
+priority 100
+snippet comma "comma" iAm
+${1:\\alpha}_1,${1:\\alpha}_2,\\cdots,${1:\\alpha}_${2:n}
+endsnippet
+
+priority 100
+snippet plus "plus" iAm
+${1:k}_1${2:\\alpha}_1+${1:k}_2${2:\\alpha}_2+\\cdots+${1:k}_${3:n}${2:\\alpha}_${3:n}
+endsnippet
+
+snippet `\b([a-z])=n` "i=1,2,\cdots,n" wAm
+``rv = m[1]``=1,2,\cdots,n
+endsnippet
+
+# ======== Common Operator Snippet ========
+
+snippet `(?<!\\)sum` "sum" wAm
+\sum\limits_{n=${1:1}}^{${2:\infty}} ${3:a_n z^n}
+endsnippet
+
+snippet taylor "taylor" wAm
+\sum\limits_{${1:k}=${2:0}}^{${3:\infty}} ${4:c_$1} (x-a)^$1 $0
+endsnippet
+
+snippet `(?<!\\)lim` "limit" wAm
+\lim\limits_{${1:n} \to ${2:\infty}} 
+endsnippet
+
+snippet `(?<!\\)prod` "product" wAm
+\prod_{${1:n=${2:1}}}^{${3:\infty}} ${4:${VISUAL}} $0
+endsnippet
+
+snippet `(?<!\\)part` "d/dx" wAm
+\frac{\partial ${1:V}}{\partial ${2:x}}$0
+endsnippet
+
+priority 100
+snippet `(?<!\\)diff` "d/dx" wAm
+\frac{\mathrm{d}${1:y}}{\mathrm{d}${2:x}}$0
+endsnippet
+
+snippet buu "bigcup" wAm
+\bigcup_{${1:i \in ${2: I}}} $0
+endsnippet
+
+snippet bnn "bigcap" wAm
+\bigcap_{${1:i \in ${2: I}}} $0
+endsnippet
+
+priority 100
+snippet `(DINT|dint)` "integral" wAm
+\int\limits_{${1:-\infty}}^{${2:\infty}} ${3} \\mathrm{d}${4:x} $0
+endsnippet
+
+# Custom: Can add more defined operator
+priority 100
+snippet `(?<![\a-zA-Z])(rank|lcm|gcd)` "math function" wAm
+\\operatorname{``rv = m[1]``}
+endsnippet
+
+snippet `(?<![\a-zA-Z])arg(max|min)` "argmin/max" wAm
+\mathop{\arg\\``rv = m[1]``}
+endsnippet
+
+# ====== Big Snippet ======
+
+snippet bigdef "Big function" iAm
+\begin{equation$6}
+    \begin{aligned}
+        $1\colon $2 &\longrightarrow $3 \\\\
+                 $4 &\longmapsto $1($4) = $5
+    \end{aligned}
+\end{equation$6}$0
+endsnippet
+
+snippet bigmin "Optimization problem" iAm
+\begin{equation$4}
+	\begin{aligned}
+		\min &\quad ${1:f(x)}\\\\
+		\text{s.t.} &\quad ${2:g(x)} \leq 0\\\\
+					&\quad ${3:h(x)} = 0\\\\
+	\end{aligned}
+\end{equaiton$4}$0
+endsnippet
+
+snippet bigmax "Optimization problem" wAm
+\begin{equation$4}
+	\begin{aligned}
+		\max &\quad ${1:f(x)}\\\\
+		\text{s.t.} &\quad ${2:g(x)} \leq 0\\\\
+					&\quad ${3:h(x)} = 0\\\\
+	\end{aligned}
+\end{equation$4}$0
+endsnippet
+
+snippet deff "Definition of function" wAm
+$1\colon ${2:\\mathbb{R\}} \to ${3:\\mathbb{R\}}, ${4:x} \mapsto $0
+endsnippet
+
+
+snippet iid "independent and identical distribution" iAm
+\overset{\text{i.i.d.}}{\sim}
+endsnippet
+
+snippet defe "define equal" wAm
+\overset{\underset{\mathrm{def}}{}}{=}
+endsnippet
+
+
+# == Matrix ==
+
+# ==== Static Matrix ====
+
+snippet pmat "pmat" wm
+\begin{pmatrix} 
+    ${1: } 
+\end{pmatrix} $0
+endsnippet
+
+snippet bmat "pmat" wm
+\begin{bmatrix} 
+    $1 
+\end{bmatrix} $0
+endsnippet
+
+snippet vecC "column vector" iAm
+\begin{pmatrix} ${1:x}_1 \\\\ ${1:x}_2 \\\\ \vdots \\\\ ${1:x}_${2:n} \end{pmatrix}
+endsnippet
+
+snippet vecR "row vector" iAm
+\begin{pmatrix} ${1:x}_1, ${1:x}_2, \cdots, ${1:x}_${2:n} \end{pmatrix}$0
+endsnippet
+
+priority 300
+snippet omis "omission" iAm
+\\begin{pmatrix}${1:1}&${2:1}&\\cdots&${4:1}\\\\${5:1}&${6:1}&\\cdots&${8:1}\\\\\\vdots&\\vdots&\\ddots&\\vdots\\\\${13:1}&${14:1}&\\cdots&${16:1}\\end{pmatrix}
+endsnippet
+
+priority 300
+snippet submat "omission" iAm
+\\begin{pmatrix}
+    ${1:a}_{11} & ${1:a}_{12} & \\cdots & ${1:a}_{1n} \\\\
+    ${1:a}_{21} & ${1:a}_{22} & \\cdots & ${1:a}_{2n} \\\\
+    \\vdots & \\vdots & \\ddots & \\vdots \\\\
+    ${1:a}_{n1} & ${1:a}_{n2} & \\cdots & ${1:a}_{nn}
+\\end{pmatrix}
+endsnippet
+
+priority 300
+snippet subplusmat "omission" iAm
+\\begin{pmatrix}
+    ${1:a}_{11}+{2:b}_{11} & ${1:a}_{12}+{2:b}_{12} & \\cdots & ${1:a}_{1n}+{2:b}_{1n} \\\\
+    ${1:a}_{21}+{2:b}_{21} & ${1:a}_{22}+{2:b}_{22} & \\cdots & ${1:a}_{2n}+{2:b}_{2n} \\\\
+    \\vdots & \\vdots & \\ddots & \\vdots \\\\
+    ${1:a}_{n1}+{2:b}_{n1} & ${1:a}_{n2}+{2:b}_{n2} & \\cdots & ${1:a}_{nn}+{2:b}_{nn}
+\\end{pmatrix}
+endsnippet
+
+snippet jacobi "jacobi" iAm
+\\begin{pmatrix}\\frac{\\partial ${1:f}_1}{\\partial ${2:x}_1}&\\frac{\\partial ${1:f}_1}{\\partial ${2:x}_2}&\\cdots&\\frac{\\partial ${1:f}_1}{\\partial ${2:x}_${3:n}}\\\\\\frac{\\partial ${1:f}_2}{\\partial ${2:x}_1}&\\frac{\\partial ${1:f}_2}{\\partial ${2:x}_2}&\\cdots&\\frac{\\partial ${1:f}_2}{\\partial ${2:x}_${3:n}}\\\\\\vdots&\\vdots&\\ddots&\\vdots\\\\\\frac{\\partial ${1:f}_${3:m}}{\\partial ${2:x}_1}&\\frac{\\partial ${1:f}_${3:m}}{\\partial ${2:x}_2}&\\cdots&\\frac{\\partial ${1:f}_${3:m}}{\\partial ${2:x}_${3:n}}\\end{pmatrix}
+endsnippet
+
+# ==== Dynamic Matrix ====
+
+priority 300
+snippet `(b|p|v)mata([1-9])` "bmatrix" iwAm
+\\begin{``rv = m[1]``matrix}``
+	let len = m[2];
+	let results = "";
+	for (var i=0; i<len; i++){
+		results += "$1 &".repeat(len-1) + " $1 \\\\\\\\";
+	}
+	rv = results;
+``\\end{``rv = m[1]``matrix}$0
+endsnippet
+
+priority 300
+snippet `(b|p|v)mat([1-9])` "bmatrix" iwAm
+\\begin{``rv = m[1]``matrix}``
+	rv = gen_matrix(m[2],m[2]);
+``\\end{``rv = m[1]``matrix}$0
+endsnippet
+
+priority 300
+snippet `vec([1-9])` "col vector" iwAm
+\\begin{pmatrix}``
+    rv = gen_matrix(m[1], 1);
+``\\end{pmatrix}$0
+endsnippet
+
+priority 300
+snippet `vecr([1-9])` "row vector" iwAm
+\\begin{pmatrix}``
+    rv = gen_matrix(1, m[1]);
+``\\end{pmatrix}$0
+endsnippet
+
+
+# == General ==
+
+snippet \box "Box" 
+``rv = '┌' + '─'.repeat(t[0].length + 2) + '┐'``
+│ $1 │
+``rv = '└' + '─'.repeat(t[0].length + 2) + '┘'``
+endsnippet
+
+
+priority 300
+snippet `table(\d)(\d)` "create table with rows and columns" wA
+``
+rv = createTable(m[1], m[2]);
+``
+endsnippet
+
+
+
+
+// == LaTeX ==
+
+snippet template "Basic template" b
+\documentclass[a4paper]{article}
+
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+\usepackage{textcomp}
+\usepackage[dutch]{babel}
+\usepackage{amsmath, amssymb}
+
+
+% figure support
+\usepackage{import}
+\usepackage{xifthen}
+\pdfminorversion=7
+\usepackage{pdfpages}
+\usepackage{transparent}
+\newcommand{\incfig}[1]{%
+	\def\svgwidth{\columnwidth}
+	\import{./figures/}{#1.pdf_tex}
+}
+
+\pdfsuppresswarningpagegroup=1
+
+\begin{document}
+	$0
+\end{document}
+endsnippet
+
+snippet table "Table environment" b
+\begin{table}[${1:htpb}]
+	\centering
+	\caption{${2:caption}}
+	\label{tab:${3:label}}
+	\begin{tabular}{${5:c}}
+	$0${5/((?<=.)c|l|r)|./(?1: & )/g}
+	\end{tabular}
+\end{table}
+endsnippet
+
+snippet fig "Figure environment" b
+\begin{figure}[${1:htpb}]
+	\centering
+	${2:\includegraphics[width=0.8\textwidth]{$3}}
+	\caption{${4:$3}}
+	\label{fig:${5:${3/\W+/-/g}}}
+\end{figure}
+endsnippet
+
+snippet enum "Enumerate" bA
+\begin{enumerate}
+	\item $0
+\end{enumerate}
+endsnippet
+
+snippet item "Itemize" bA
+\begin{itemize}
+	\item $0
+\end{itemize}
+endsnippet
+
+snippet desc "Description" b
+\begin{description}
+	\item[$1] $0
+\end{description}
+endsnippet
+
+snippet pac "Package" b
+\usepackage[${1:options}]{${2:package}}$0
+endsnippet

--- a/latex.hsnips
+++ b/latex.hsnips
@@ -58,7 +58,7 @@ endglobal
 
 
 snippet // "Fraction" iAm
-\frac{$1}{$2}$0
+\\frac{${1:${VISUAL}}}{$2}$0
 endsnippet 
 
 snippet `((\d+)|(\d*)(\\)?([A-Za-z!]+)((\^|_)(\{\d+\}|\d))*)/` "Fraction no ()" iAm
@@ -278,21 +278,12 @@ snippet eps "epsilon" wAm
 \epsilon
 endsnippet
 
-snippet `(?<=\b|\d+)(?<!\\)(ell|nabla|notin)` "symbol" iAm
-\\``rv = m[1]``
-endsnippet
-
-
-snippet `(?<=\b|\d+)(?<!\\)(arcsin|arccos|arctan|arccot|arccsc|arcsec|pi|zeta|oint|iiint|iint|int)` "ln" wAm
-\\``rv = m[1]``
-endsnippet
-
-snippet `(?<=\b|\d+)(?<!\\)(sin|cos|arccot|cot|csc|ln|log|exp|star|perp)` "ln" wAm
-\\``rv = m[1]``
+snippet `(?<=\b|\d+)(?<!\\)(sin|cos|arccot|cot|csc|ln|log|exp|star|perp|arcsin|arccos|arctan|arccot|arccsc|arcsec|pi|zeta|oint|iiint|iint|int|ell|nabla|notin)` "function" wAm
+\\``rv = m[1]`` 
 endsnippet
 
 snippet `(?<=\b|\d+)(?<!\\)(mu|alpha|sigma|rho|beta|gamma|delta|zeta|eta|varepsilon|theta|iota|kappa|vartheta|lambda|nu|pi|rho|tau|upsilon|varphi|phi|chi|psi|omega|Gamma|Delta|Theta|Lambda|Xi|Pi|Sigma|Upsilon|Phi|Psi|Omega)` "greek" wAm
-\\``rv = m[1]``
+\\``rv = m[1]`` 
 endsnippet
 
 # ==== Space Symbol ====
@@ -392,20 +383,8 @@ endsnippet
 
 # ==== Auto Math Mode ====
 
-snippet im "inline Math" wA
+snippet lm "inline Math" wA
 $${1}$$0
-endsnippet
-
-snippet im "inline Math" wA
-$${1}$``
-let str = t[0];
-let test = str.charAt(str.length - 1);
-if (test != ',' &&  test != '.' &&  test != '-' && test !='?' && test !=' '){
-	rv = ' ';
-}
-else{
-	rv = '';
-}``$2
 endsnippet
 
 snippet dm "display Math" wA
@@ -475,6 +454,7 @@ snippet [ "auto close []" iA
 [${1}]
 endsnippet
 
+priority 200
 snippet norm iAm
 \left\| ${1} \right\|_{$2}$3
 endsnippet
@@ -575,7 +555,7 @@ snippet dint "integral" wAm
 endsnippet
 
 priority 200
-snippet `c(o|n)?(l|n)?(b|c)?int` "s integral" wAm
+snippet `c(o|n)?(l|n)?(b|c)?int` "s 	egral" wAm
 ``
 let final = "\\"; // init
 let isO = m[1] == "o";
@@ -755,6 +735,8 @@ snippet `table(\d)(\d)` "create table with rows and columns" wA
 rv = createTable(m[1], m[2]);
 ``
 endsnippet
+
+
 
 
 

--- a/markdown.hsnips
+++ b/markdown.hsnips
@@ -58,7 +58,7 @@ endglobal
 
 
 snippet // "Fraction" iAm
-\frac{$1}{$2}$0
+\\frac{${1:${VISUAL}}}{$2}$0
 endsnippet 
 
 snippet `((\d+)|(\d*)(\\)?([A-Za-z!]+)((\^|_)(\{\d+\}|\d))*)/` "Fraction no ()" iAm
@@ -278,21 +278,12 @@ snippet eps "epsilon" wAm
 \epsilon
 endsnippet
 
-snippet `(?<=\b|\d+)(?<!\\)(ell|nabla|notin)` "symbol" iAm
-\\``rv = m[1]``
-endsnippet
-
-
-snippet `(?<=\b|\d+)(?<!\\)(arcsin|arccos|arctan|arccot|arccsc|arcsec|pi|zeta|oint|iiint|iint|int)` "ln" wAm
-\\``rv = m[1]``
-endsnippet
-
-snippet `(?<=\b|\d+)(?<!\\)(sin|cos|arccot|cot|csc|ln|log|exp|star|perp)` "ln" wAm
-\\``rv = m[1]``
+snippet `(?<=\b|\d+)(?<!\\)(sin|cos|arccot|cot|csc|ln|log|exp|star|perp|arcsin|arccos|arctan|arccot|arccsc|arcsec|pi|zeta|oint|iiint|iint|int|ell|nabla|notin)` "function" wAm
+\\``rv = m[1]`` 
 endsnippet
 
 snippet `(?<=\b|\d+)(?<!\\)(mu|alpha|sigma|rho|beta|gamma|delta|zeta|eta|varepsilon|theta|iota|kappa|vartheta|lambda|nu|pi|rho|tau|upsilon|varphi|phi|chi|psi|omega|Gamma|Delta|Theta|Lambda|Xi|Pi|Sigma|Upsilon|Phi|Psi|Omega)` "greek" wAm
-\\``rv = m[1]``
+\\``rv = m[1]`` 
 endsnippet
 
 # ==== Space Symbol ====
@@ -392,20 +383,8 @@ endsnippet
 
 # ==== Auto Math Mode ====
 
-snippet im "inline Math" wA
+snippet lm "inline Math" wA
 $${1}$$0
-endsnippet
-
-snippet im "inline Math" wA
-$${1}$``
-let str = t[0];
-let test = str.charAt(str.length - 1);
-if (test != ',' &&  test != '.' &&  test != '-' && test !='?' && test !=' '){
-	rv = ' ';
-}
-else{
-	rv = '';
-}``$2
 endsnippet
 
 snippet dm "display Math" wA
@@ -475,6 +454,7 @@ snippet [ "auto close []" iA
 [${1}]
 endsnippet
 
+priority 200
 snippet norm iAm
 \left\| ${1} \right\|_{$2}$3
 endsnippet
@@ -575,7 +555,7 @@ snippet dint "integral" wAm
 endsnippet
 
 priority 200
-snippet `c(o|n)?(l|n)?(b|c)?int` "s integral" wAm
+snippet `c(o|n)?(l|n)?(b|c)?int` "s 	egral" wAm
 ``
 let final = "\\"; // init
 let isO = m[1] == "o";

--- a/markdown.hsnips
+++ b/markdown.hsnips
@@ -1,0 +1,758 @@
+global
+// JavaScript code
+function gen_matrix(nrow, ncol) {
+	let results = "";
+	let order = 1;
+	for (var i=0; i<nrow; i++){
+		results += '	';
+		for(var j = 0;j <ncol-1;j++){
+			results += "$" +(order ).toString() + " & ";
+			order ++;
+		}
+		results += "$"+(order).toString() +" \\\\" + "\\ ";
+		order ++;
+	}
+	return results;
+}
+
+function tes_matrix(nrow, ncol,t) {
+	let results = "";
+	let order = 1;
+	for (var i=0; i<nrow; i++){
+		results += '	';
+		for(var j = 0;j <ncol-1;j++){
+			if (order > 1 ){
+				results += "${" +(order ).toString() + ":" + t[order-2] + "}\t & ";
+			}
+			else{
+				results += "$" +(order ).toString()  + " & ";
+			}
+			order ++;
+		}
+		results += "$"+(order).toString() +" \\\\" + "\\ ";
+		order ++;
+	}
+	return results;
+}
+
+// 输出一个表格
+function createTable(rows, cols) {
+    let ret = "";
+    for (let i = 0; i < parseInt(rows) + 2; i++) {
+        for (let j = 0; j < parseInt(cols); j++) {
+            if (i === 1) {
+                ret += "|---";
+            } else {
+                ret += "|  ";
+            }
+        }
+        ret += "|\n"
+    }
+    return ret;
+}
+
+endglobal
+
+
+# == Fraction Match ==
+
+
+snippet // "Fraction" iAm
+\frac{$1}{$2}$0
+endsnippet 
+
+snippet `((\d+)|(\d*)(\\)?([A-Za-z!]+)((\^|_)(\{\d+\}|\d))*)/` "Fraction no ()" iAm
+\frac{``rv = m[1]``}{$1}$0
+endsnippet
+
+priority 200
+snippet `(?<=\s)(\\mu|\\alpha|\\sigma|\\rho|\\beta|\\gamma|\\delta|\\zeta|\\eta|\\varepsilon|\\theta|\\iota|\\kappa|\\vartheta|\\lambda|\\nu|\\pi|\\rho|\\tau|\\upsilon|\\phi|\\chi|\\psi|\\omega|\\Gamma|\\Delta|\\Theta|\\Lambda|\\Xi|\\Pi|\\Sigma|\\Upsilon|\\Phi|\\Psi|\\Omega|[A-Za-z]{1,2})?(_[A-Za-z0-9]|_\{[^}]+\})?(\^[A-Za-z0-9]|\^\{[^}]+\})?(_[A-Za-z0-9]|_\{[^}]+\})?(\([^)]+\))(_[A-Za-z0-9]|_\{[^}]+\})?(\^[A-Za-z0-9]|\^\{[^}]+\})?(_[A-Za-z0-9]|_\{[^}]+\})?\/` "Fraction with ()" iAm
+``rv = "\\frac{" + m.slice(1, m.length).join('') + "}{$1}$2"``
+endsnippet
+
+# == Hat Operation ==
+
+# ==== Auto Capture Hat Operation ====
+snippet `(\(?)(\\?[a-zA-Z]\w*)(\)?)(hbar|BAR)` "Bar" iAm
+\overline{``rv = m[1] + m[2] + m[3]``}
+endsnippet
+
+snippet `(\\?[a-zA-Z]\w*)(htd|TD)` "tilde" iAm
+\widetilde{``rv = m[1]``}
+endsnippet
+
+snippet `(\\?[a-zA-Z]\w*)(hat|HAT)` "hat" iAm
+\hat{``rv = m[1]``}
+endsnippet
+
+snippet `(\\?[a-zA-Z]\w*)(hvec)` "Vector postfix" iAm
+\vec{``rv = m[1]``}
+endsnippet
+
+snippet `(\\?[a-zA-Z]\w*)(rta)` "Vector postfix" iAm
+\overrightarrow{``rv = m[1]``}
+endsnippet
+
+snippet `(\\?[a-zA-Z]\w*)(hdot)` "dot" iAm
+\dot{``rv = m[1]``}
+endsnippet
+
+snippet `(\\?[a-zA-Z]\w*)(hddot)` "ddot" iAm
+\ddot{``rv = m[1]``}
+endsnippet
+
+# ===== Static Hat Operation ====
+
+snippet hbar "bar" iAm
+\overline{$1}$0
+endsnippet
+
+snippet hat "hat" iAm
+\hat{$1}$0
+endsnippet
+
+snippet hsq "\sqrt{}" iAm
+\sqrt{${1}}$0
+endsnippet
+
+# == Superscript Operation ==
+
+snippet invs "inverse" wAm
+^{-1}
+endsnippet
+
+priority 10000
+snippet TR "inverse" iAm
+^{\mathsf{T}}
+endsnippet
+
+snippet CL "complement" wAm
+^{c}
+endsnippet
+
+snippet R+ "R0+" iAm
+R_0^+
+endsnippet
+
+snippet pow "power" iAm
+^{${1:2}}$0
+endsnippet
+
+# == Subscript Operation ==
+
+snippet td "subscript" iAm
+_{${1}}$0
+endsnippet
+
+snippet `([A-Za-z])(\d)` "auto subscript" wAm
+`` rv = m[1] + "_" + m[2]``
+endsnippet
+
+priority 100
+snippet `([A-Za-z])_(\d{2})` "auto subscript" wAm
+`` rv = m[1] + "_{" + m[2] + "}$0" ``
+endsnippet
+
+priority 100
+snippet `([A-Za-z])S(\d)` "auto subscript" wAm
+`` rv = m[1] + "_{" + m[2] + "$1}$2"``
+endsnippet
+
+snippet `\b(?<!\\)([A-Za-z])([a-z])\2` "auto subscript 2" iAm
+`` rv = m[1] + "_" + m[2].substring(0, 1) ``
+endsnippet
+
+snippet `\b(?<!\\)([A-Za-z])S([a-z])\2` "auto subscript 2" iAm
+`` rv = m[1] + "_{" + m[2].substring(0, 1) + "$1}$2"``
+endsnippet
+
+# Custom: Add more greek letters
+snippet `(\\mu|\\alpha|\\sigma|\\rho|\\beta|\\gamma|\\delta|\\zeta|\\eta|\\varepsilon|\\theta|\\iota|\\kappa|\\vartheta|\\lambda|\\nu|\\pi|\\rho|\\tau|\\upsilon|\\phi|\\chi|\\psi|\\omega|\\Gamma|\\Delta|\\Theta|\\Lambda|\\Xi|\\Pi|\\Sigma|\\Upsilon|\\Phi|\\Psi|\\Omega)([a-z])\2` "auto subscript for greek letter" iAm
+`` rv = m[1] + "_" + m[2].substring(0, 1) ``
+endsnippet
+
+snippet `(\\mu|\\alpha|\\sigma|\\rho|\\beta|\\gamma|\\delta|\\zeta|\\eta|\\varepsilon|\\theta|\\iota|\\kappa|\\vartheta|\\lambda|\\nu|\\pi|\\rho|\\tau|\\upsilon|\\phi|\\chi|\\psi|\\omega|\\Gamma|\\Delta|\\Theta|\\Lambda|\\Xi|\\Pi|\\Sigma|\\Upsilon|\\Phi|\\Psi|\\Omega)S([a-z])\2` "auto subscript for greek letter" iAm
+`` rv = m[1] + "_{${1:" + m[2].substring(0, 1) + "}}$2"``
+endsnippet
+
+# == Font Operation ==
+
+# ==== Static Operation ====
+
+snippet txt "text" iAm
+\text{$1}$0
+endsnippet
+
+snippet tit "text it" iAm
+\textit{$1}$0
+endsnippet
+
+snippet mcal "mathcal" im
+\mathcal{$1}$0
+endsnippet
+
+snippet mbb "mathbb" iAm
+\mathbb{$1}$0
+endsnippet
+
+snippet mbf "mathbb" iAm
+\mathbf{$1}$0
+endsnippet
+
+snippet mbf "mathbm" iAm
+\mathbf{$1}$0
+endsnippet
+
+# ==== Dynamic Operation ====
+
+priority 100
+snippet `(\\?[a-zA-Z]\w*)(bf|BF)` "mathbf" iAm
+\mathbf{``rv = m[1]``}
+endsnippet
+
+priority 100
+snippet `(\\?[a-zA-Z]\w*)(bm|BM)` "mathbm" iAm
+\bm{``rv = m[1]``}
+endsnippet
+
+priority 100
+snippet `(\\?[a-zA-Z]\w*)(bs)` "boldsymbol" iAm
+\boldsymbol{``rv = m[1]``}
+endsnippet
+
+priority 100
+snippet `(\\?[a-zA-Z]\w*)mcal` "mathcal" iAm
+\mathcal{``rv = m[1].toUpperCase() ``} $0
+endsnippet
+
+priority 100
+snippet `(?<!\\)\b([a-zA-Z]+)rm` "mathrm" iAm
+\mathrm{``rv = m[1]``}
+endsnippet
+
+priority 100
+snippet `(\\?[a-zA-Z]\w*)mbb` iAm
+\mathbb{``rv = m[1]``} $0
+endsnippet
+
+
+# == Auto Symbol ==
+
+snippet oo "\infty" wAmm
+\infty
+endsnippet
+
+snippet ... "cdots" iAm
+\cdots 
+endsnippet
+
+snippet <> "hokje" iA
+\diamond 
+endsnippet
+
+# +... -> , \cdots
+# -  ... -> , \cdots
+# add a space if there already is one.
+priority 101
+snippet `(?<=[-+])\s*\.\.\.` "smart cdots" irA
+ \cdots 
+endsnippet
+
+# It seems that \ldots is only used when , ..., 
+# ,... -> , \ldots
+# ,  ... -> , \ldots
+priority 101
+snippet `(?<=,)(\s*)\.\.\.` "smart ldots" irA
+ \ldots 
+endsnippet
+
+snippet ** "dot multiply" iAm
+\cdot 
+endsnippet
+
+snippet xx "cross" iAm
+\times 
+endsnippet
+
+snippet eps "epsilon" wAm
+\epsilon
+endsnippet
+
+snippet `(?<=\b|\d+)(?<!\\)(ell|nabla|notin)` "symbol" iAm
+\\``rv = m[1]``
+endsnippet
+
+
+snippet `(?<=\b|\d+)(?<!\\)(arcsin|arccos|arctan|arccot|arccsc|arcsec|pi|zeta|oint|iiint|iint|int)` "ln" wAm
+\\``rv = m[1]``
+endsnippet
+
+snippet `(?<=\b|\d+)(?<!\\)(sin|cos|arccot|cot|csc|ln|log|exp|star|perp)` "ln" wAm
+\\``rv = m[1]``
+endsnippet
+
+snippet `(?<=\b|\d+)(?<!\\)(mu|alpha|sigma|rho|beta|gamma|delta|zeta|eta|varepsilon|theta|iota|kappa|vartheta|lambda|nu|pi|rho|tau|upsilon|varphi|phi|chi|psi|omega|Gamma|Delta|Theta|Lambda|Xi|Pi|Sigma|Upsilon|Phi|Psi|Omega)` "greek" wAm
+\\``rv = m[1]``
+endsnippet
+
+# ==== Space Symbol ====
+snippet `(?<=\b|\d+)(?<!\\)(quad)` "ln" wAm
+\\``rv = m[1]``
+endsnippet
+
+# ==== Logic Symbol ====
+
+
+snippet -> "to" iAm
+\to 
+endsnippet
+
+snippet !> "mapsto" iAm
+\mapsto 
+endsnippet
+
+snippet vdash "vdash" iAm
+\\vdash
+endsnippet
+
+snippet => "implies" iAm
+\implies
+endsnippet
+
+snippet =< "implied by" iAm
+\impliedby
+endsnippet
+
+snippet iff "if and only if" iAm
+\iff
+endsnippet
+
+snippet EE "exist" iAm
+\exists 
+endsnippet
+
+
+snippet AA "forall" iAm
+\forall 
+endsnippet
+
+snippet bec "because" iAm
+\because 
+endsnippet
+
+snippet thr "therefore" iAm
+\therefore 
+endsnippet
+
+
+# ==== Compare Symbol ====
+
+snippet -- "setminus" iAm
+\setminus
+endsnippet
+
+snippet >= "greater than" iAm
+\geqslant $0
+endsnippet
+
+snippet dis "displaystyle" iAm
+\displaystyle 
+endsnippet
+
+snippet <= "less than" iAm
+\leqslant $0
+endsnippet
+
+snippet != "no equals" iAm
+\neq 
+endsnippet
+
+snippet == " constan equals" iAm
+\equiv 
+endsnippet
+
+snippet ~~ " Amppro equals" iAm
+\thickapprox 
+endsnippet
+
+snippet ~= " Amppro equals2" iAm
+\cong
+endsnippet
+
+snippet >> ">>" iAm
+\gg
+endsnippet
+
+
+snippet << "<<" iAm
+\ll
+endsnippet
+
+# == Auto Environment ==
+
+# ==== Auto Math Mode ====
+
+snippet im "inline Math" wA
+$${1}$$0
+endsnippet
+
+snippet im "inline Math" wA
+$${1}$``
+let str = t[0];
+let test = str.charAt(str.length - 1);
+if (test != ',' &&  test != '.' &&  test != '-' && test !='?' && test !=' '){
+	rv = ' ';
+}
+else{
+	rv = '';
+}``$2
+endsnippet
+
+snippet dm "display Math" wA
+$$
+${1}
+$$$0
+endsnippet
+
+# ==== Common Environment ====
+
+snippet case "cases" wAm
+\begin{cases}
+	$1 \\\\
+\end{cases}
+endsnippet
+
+snippet ali "aligned" wAm
+\begin{aligned}
+$1 \\\\
+\end{aligned}
+endsnippet
+
+# == Auto Adaptive Close ==
+
+snippet ceil "ceil" iAm
+\left\lceil $1 \right\rceil $0
+endsnippet
+
+snippet floor "floor" iAm
+\left\lfloor $1 \right\rfloor$0
+endsnippet
+
+priority 100
+snippet @( "left( right)" Aim
+\left( ${1} \right) $0
+endsnippet
+
+priority 100
+snippet @| "left| right|" Aim
+\left| ${1} \right| $0
+endsnippet
+
+priority 100
+snippet @{ "left\{ right\}" Aim
+\left\\{ ${1} \right\\} $0
+endsnippet
+
+priority 100
+snippet @[ "left[ right]" Aim
+\left[ ${1} \right] $0
+endsnippet
+
+priority 100
+snippet @< "leftangle rightangle" iAm
+\left<${1} \right>$0
+endsnippet
+
+snippet ( "auto close ()" iA
+(${1})
+endsnippet
+
+snippet { "auto close {}" iA
+{${1}}
+endsnippet
+
+snippet [ "auto close []" iA
+[${1}]
+endsnippet
+
+snippet norm iAm
+\left\| ${1} \right\|_{$2}$3
+endsnippet
+
+# == Snippet ==
+
+# ==== General Snippet ====
+
+# ====== Lite Snippet ======
+
+snippet tag "tag" iAm
+\tag{$1}
+endsnippet
+
+snippet xyb "Auto (x, y)" iAm
+(x, y)
+endsnippet
+
+snippet xyzb "Auto (x, y ,z)" iAm
+(x, y, z)
+endsnippet
+
+priority 100
+snippet `\b([a-zA-Z])n(\d)` "x[n+1]" iAm
+``rv = m[1]``_{${1:n}+``rv = m[2]``}$0
+endsnippet
+
+# Unkown
+snippet rij "mrij" iAm
+(${1:x}_${2:n})_{${3:$2} \\in ${4:N}}$0
+endsnippet
+
+priority 200
+snippet abs "absolute value" iAm
+\left\vert ${1} \right\vert $0
+endsnippet
+
+snippet beg "begin{} / end{}" bA
+\\begin{$1}
+	$0
+\\end{$1}
+endsnippet
+
+# ======== N Series ========
+
+priority 100
+snippet comma "comma" iAm
+${1:\\alpha}_1,${1:\\alpha}_2,\\cdots,${1:\\alpha}_${2:n}
+endsnippet
+
+priority 100
+snippet plus "plus" iAm
+${1:k}_1${2:\\alpha}_1+${1:k}_2${2:\\alpha}_2+\\cdots+${1:k}_${3:n}${2:\\alpha}_${3:n}
+endsnippet
+
+snippet `\b([a-z])=n` "i=1,2,\cdots,n" wAm
+``rv = m[1]``=1,2,\cdots,n
+endsnippet
+
+# ======== Common Operator Snippet ========
+
+snippet `(?<!\\)sum` "sum" wAm
+\sum\limits_{n=${1:1}}^{${2:\infty}} ${3:a_n z^n}
+endsnippet
+
+snippet taylor "taylor" wAm
+\sum\limits_{${1:k}=${2:0}}^{${3:\infty}} ${4:c_$1} (x-a)^$1 $0
+endsnippet
+
+snippet `(?<!\\)lim` "limit" wAm
+\lim\limits_{${1:n} \to ${2:\infty}} 
+endsnippet
+
+snippet `(?<!\\)prod` "product" wAm
+\prod_{${1:n=${2:1}}}^{${3:\infty}} ${4:${VISUAL}} $0
+endsnippet
+
+snippet `(?<!\\)part` "d/dx" wAm
+\frac{\partial ${1:V}}{\partial ${2:x}}$0
+endsnippet
+
+priority 100
+snippet `(?<!\\)diff` "d/dx" wAm
+\frac{\mathrm{d}${1:y}}{\mathrm{d}${2:x}}$0
+endsnippet
+
+snippet buu "bigcup" wAm
+\bigcup_{${1:i \in ${2: I}}} $0
+endsnippet
+
+snippet bnn "bigcap" wAm
+\bigcap_{${1:i \in ${2: I}}} $0
+endsnippet
+
+priority 100
+snippet dint "integral" wAm
+\int_{${1:-\infty}}^{${2:\infty}} ${3} ~\\mathrm{d}${4:x} $0
+endsnippet
+
+priority 200
+snippet `c(o|n)?(l|n)?(b|c)?int` "s integral" wAm
+``
+let final = "\\"; // init
+let isO = m[1] == "o";
+(isO) ? final += "o" : "" // o option
+let b = 1;
+let isL = m[2] == "l";
+(m[3] == 'b') ? b = 2 : (m[3] == 'c') ? b = 3 : 1;
+for (let i = 0; i < b - 1; i++) {
+final += "i";
+}
+final += "int";
+final += ((b >= 2) || (b != 1 && !isO && isL)) ? "\\limits" : "";
+let r = (b == 3) ? "E" : (b == 1 && (isL || isO)) ? "C" : "R";
+final += ((b >= 2) || isO || (b == 1 && isL)) ? "_{${1:" + r + "}}" : "_{${1:-\\infty}}^{${2:\\infty}}";
+let x = (b == 2) ? "A" : (b == 3) ? "V" : (b == 1 && isL) ? "s" : "x";
+final += " ${3} ~\\mathrm{d}${4:" + x + "} $0";
+rv = final;
+``
+endsnippet
+
+# Custom: Can add more defined operator
+priority 100
+snippet `(?<![\a-zA-Z])(rank|lcm|gcd)` "math function" wAm
+\\operatorname{``rv = m[1]``}
+endsnippet
+
+snippet `(?<![\a-zA-Z])arg(max|min)` "argmin/max" wAm
+\mathop{\arg\\``rv = m[1]``}
+endsnippet
+
+# ====== Big Snippet ======
+
+snippet bigdef "Big function" iAm
+\begin{equation$6}
+    \begin{aligned}
+        $1\colon $2 &\longrightarrow $3 \\\\
+                 $4 &\longmapsto $1($4) = $5
+    \end{aligned}
+\end{equation$6}$0
+endsnippet
+
+snippet bigmin "Optimization problem" iAm
+\begin{equation$4}
+	\begin{aligned}
+		\min &\quad ${1:f(x)}\\\\
+		\text{s.t.} &\quad ${2:g(x)} \leq 0\\\\
+					&\quad ${3:h(x)} = 0\\\\
+	\end{aligned}
+\end{equaiton$4}$0
+endsnippet
+
+snippet bigmax "Optimization problem" wAm
+\begin{equation$4}
+	\begin{aligned}
+		\max &\quad ${1:f(x)}\\\\
+		\text{s.t.} &\quad ${2:g(x)} \leq 0\\\\
+					&\quad ${3:h(x)} = 0\\\\
+	\end{aligned}
+\end{equation$4}$0
+endsnippet
+
+snippet deff "Definition of function" wAm
+$1\colon ${2:\\mathbb{R\}} \to ${3:\\mathbb{R\}}, ${4:x} \mapsto $0
+endsnippet
+
+
+snippet iid "independent and identical distribution" iAm
+\overset{\text{i.i.d.}}{\sim}
+endsnippet
+
+snippet defe "define equal" wAm
+\overset{\underset{\mathrm{def}}{}}{=}
+endsnippet
+
+
+# == Matrix ==
+
+# ==== Static Matrix ====
+
+snippet pmat "pmat" wm
+\begin{pmatrix} 
+    ${1: } 
+\end{pmatrix} $0
+endsnippet
+
+snippet bmat "pmat" wm
+\begin{bmatrix} 
+    $1 
+\end{bmatrix} $0
+endsnippet
+
+snippet vecC "column vector" iAm
+\begin{pmatrix} ${1:x}_1 \\\\ ${1:x}_2 \\\\ \vdots \\\\ ${1:x}_${2:n} \end{pmatrix}
+endsnippet
+
+snippet vecR "row vector" iAm
+\begin{pmatrix} ${1:x}_1, ${1:x}_2, \cdots, ${1:x}_${2:n} \end{pmatrix}$0
+endsnippet
+
+priority 300
+snippet omis "omission" iAm
+\\begin{pmatrix}${1:1}&${2:1}&\\cdots&${4:1}\\\\${5:1}&${6:1}&\\cdots&${8:1}\\\\\\vdots&\\vdots&\\ddots&\\vdots\\\\${13:1}&${14:1}&\\cdots&${16:1}\\end{pmatrix}
+endsnippet
+
+priority 300
+snippet submat "omission" iAm
+\\begin{pmatrix}
+    ${1:a}_{11} & ${1:a}_{12} & \\cdots & ${1:a}_{1n} \\\\
+    ${1:a}_{21} & ${1:a}_{22} & \\cdots & ${1:a}_{2n} \\\\
+    \\vdots & \\vdots & \\ddots & \\vdots \\\\
+    ${1:a}_{n1} & ${1:a}_{n2} & \\cdots & ${1:a}_{nn}
+\\end{pmatrix}
+endsnippet
+
+priority 300
+snippet subplusmat "omission" iAm
+\\begin{pmatrix}
+    ${1:a}_{11}+{2:b}_{11} & ${1:a}_{12}+{2:b}_{12} & \\cdots & ${1:a}_{1n}+{2:b}_{1n} \\\\
+    ${1:a}_{21}+{2:b}_{21} & ${1:a}_{22}+{2:b}_{22} & \\cdots & ${1:a}_{2n}+{2:b}_{2n} \\\\
+    \\vdots & \\vdots & \\ddots & \\vdots \\\\
+    ${1:a}_{n1}+{2:b}_{n1} & ${1:a}_{n2}+{2:b}_{n2} & \\cdots & ${1:a}_{nn}+{2:b}_{nn}
+\\end{pmatrix}
+endsnippet
+
+snippet jacobi "jacobi" iAm
+\\begin{pmatrix}\\frac{\\partial ${1:f}_1}{\\partial ${2:x}_1}&\\frac{\\partial ${1:f}_1}{\\partial ${2:x}_2}&\\cdots&\\frac{\\partial ${1:f}_1}{\\partial ${2:x}_${3:n}}\\\\\\frac{\\partial ${1:f}_2}{\\partial ${2:x}_1}&\\frac{\\partial ${1:f}_2}{\\partial ${2:x}_2}&\\cdots&\\frac{\\partial ${1:f}_2}{\\partial ${2:x}_${3:n}}\\\\\\vdots&\\vdots&\\ddots&\\vdots\\\\\\frac{\\partial ${1:f}_${3:m}}{\\partial ${2:x}_1}&\\frac{\\partial ${1:f}_${3:m}}{\\partial ${2:x}_2}&\\cdots&\\frac{\\partial ${1:f}_${3:m}}{\\partial ${2:x}_${3:n}}\\end{pmatrix}
+endsnippet
+
+# ==== Dynamic Matrix ====
+
+priority 300
+snippet `(b|p|v)mata([1-9])` "bmatrix" iwAm
+\\begin{``rv = m[1]``matrix}``
+	let len = m[2];
+	let results = "";
+	for (var i=0; i<len; i++){
+		results += "$1 &".repeat(len-1) + " $1 \\\\\\\\";
+	}
+	rv = results;
+``\\end{``rv = m[1]``matrix}$0
+endsnippet
+
+priority 300
+snippet `(b|p|v)mat([1-9])` "bmatrix" iwAm
+\\begin{``rv = m[1]``matrix}``
+	rv = gen_matrix(m[2],m[2]);
+``\\end{``rv = m[1]``matrix}$0
+endsnippet
+
+priority 300
+snippet `vec([1-9])` "col vector" iwAm
+\\begin{pmatrix}``
+    rv = gen_matrix(m[1], 1);
+``\\end{pmatrix}$0
+endsnippet
+
+priority 300
+snippet `vecr([1-9])` "row vector" iwAm
+\\begin{pmatrix}``
+    rv = gen_matrix(1, m[1]);
+``\\end{pmatrix}$0
+endsnippet
+
+
+# == General ==
+
+snippet \box "Box" 
+``rv = '┌' + '─'.repeat(t[0].length + 2) + '┐'``
+│ $1 │
+``rv = '└' + '─'.repeat(t[0].length + 2) + '┘'``
+endsnippet
+
+
+priority 300
+snippet `table(\d)(\d)` "create table with rows and columns" wA
+``
+rv = createTable(m[1], m[2]);
+``
+endsnippet
+


### PR DESCRIPTION
## Vscode-LaTeX-Snippet

- 正在尝试通过大规模测试，检验表达式和 Snippet 稳定性 / 适用性
- 有任何需求可以直接发 Comment

![2021-08-18 04 29 01](https://user-images.githubusercontent.com/25319400/129998961-860edc16-9afb-401d-b437-4824660f8ae6.gif)


### 特性介绍

- [x] LaTeX 模板环境系列
  - template, table, fig, enum, item, decs, pac 片段
  - 在 TeX 文件中匹配 部分自动展开 部分手动展开
- [x] 复杂 Fraction 匹配
  - `f^((n))(z)!^{sth}_{sth}/ -> \frac{f^((n))(z)!^{sth}_{sth}}{}`
  - 前面必须有空格
  - 需要大量测试才能确保稳定性
- [x] 更统一的代码风格 / Priority 设计 / 类别管理
- [x] 更稳定的正则匹配表达式
  - 帽子操作使用 `h` 开头，如 `hbar` 而非之前的 `bar`，`hvec` 而非 `vec` （向量帽），`hdot`，`hddot`, `hsq` 等等
  - 使用 `rta` 而非 `ra`，表示 `\overrightarrow`
  - 添加更多的零宽断言和限制条件
- [x] 更方便的字体支持
  - `txt -> \text`
  - `tit -> \textit`
  - `Nbf -> \mathbf{N}`
  - `Nbm -> \mathbm{N}`
  - `Nbs -> \boldsymbol{N}`
  - `rmcal -> \mathcal{R}` (Auto Uppercase)
  - `rmbb -> \mathbb{r}`
  - `ReLUrm -> \mathrm{ReLU}`
- [x] 更方便的上标操作
  - `pow` 自己选择 
  - `TR` 转置，使用更标准的 `^\mathsf{T}`
- [x] 更方便的下标操作
  - `a12 -> a_{12}`
  - 任意一个（含希腊字母等特殊符号）字母，带上两次重复的小写字母，自动添加下标。例 `\alphajj -> \alpha_j`
    - 在两者间插入一个 S 则会插入括号和自动后向输入 `\alphaSjj -> \alpha_{j<first cursor>}<second cursor>`
   - `xn1 -> x_{n+1}` 后面的数字可以换成任意数字
- [x] 更高级和智能的积分片段 `cint`
  - `c(o)(l)(b/c)int`, 如 `coint` 就是一阶曲线积分，`cbint` 就是二重积分，`ccint` 就是三重积分，`clint` 是一阶曲线积分的简写版等等组合方式
- [x] `lim` 和 `sum` 片段，加入` \limits` 使得行内公式更美观
- [x] 整理了括号，和自适应括号的 Snippet
  - 建议关闭 vscode 对 `markdown` 和 `tex` 文件的自动关闭括号，使用 snippet 括号可以 `tab` 键瞬移
  - `@|, @(, @{, @[, @<` 等片段，是自适应括号
  - `abs` 是绝对值（渲染情况更好）
  - `norm` 范数，双竖线
  - `<>` 会变成 `\diamond` 符号，建议使用 `@<`
- [ ] 太多更新了 有时间再来写（

### 注意事项
- 多多使用 `Tab` 和 `Shift + Tab` 键和片段中的 Placeholder 等属性。
- 推荐配合 Conceal 插件，用于将 `\delta` 等字符变为 `∂`便于观看，可以近乎还原 Vim 端 LaTeX Snippet 体验
- 由于配置使用了大量的正则表达式，所以 HyperSnippet 无法自动补全（如 alpha, beta, delta 等字母，后期考虑手动手动生成这些片段，脱离正则表达式，现在还是有点麻烦）
  - 所以正则表达式的 Snippet 尽量全部使用自动展开
- 目前来说这些更改几乎都不稳定（没有大规模文档输入测试），可能会影响正常的公式书写。
  - 如果有 Snippet 尽量不要自己去写命令，因为很容易就误触某个 Snippet 导致书写混乱