### PR TITLE
several changes for mathbb

### DIFF
--- a/latex.hsnips
+++ b/latex.hsnips
@@ -261,7 +261,11 @@ snippet mbm "mathbm" iAm
 \mathbm{$1}$0
 endsnippet
 
-snippet TT "R" iAm
+snippet KK "K" iAm
+^{\mathrm{K}}
+endsnippet
+
+snippet TT "T" iAm
 ^{\mathrm{T}}
 endsnippet
 
@@ -271,10 +275,6 @@ endsnippet
 
 snippet NN "N" iAm
 \mathbb{N}
-endsnippet
-
-snippet ZZ "Z" iAm
-\mathbb{Z}
 endsnippet
 
 snippet ZZ "Z" iAm

--- a/markdown.hsnips
+++ b/markdown.hsnips
@@ -239,7 +239,11 @@ snippet mbm "mathbm" iAm
 \mathbm{$1}$0
 endsnippet
 
-snippet TT "R" iAm
+snippet KK "K" iAm
+^{\mathrm{K}}
+endsnippet
+
+snippet TT "T" iAm
 ^{\mathrm{T}}
 endsnippet
 
@@ -249,10 +253,6 @@ endsnippet
 
 snippet NN "N" iAm
 \mathbb{N}
-endsnippet
-
-snippet ZZ "Z" iAm
-\mathbb{Z}
 endsnippet
 
 snippet ZZ "Z" iAm


### PR DESCRIPTION
1. remove duplicate snippet `ZZ`;
2. label for snippet  `TT` should be `"T"`;
3. add snippet `KK` for `\mathbb{K}`, where $\mathbb{K}$ usually denotes an abstract field $\mathbb{R}$ or $\mathbb{C}$;
4. change them for both latex and markdown.


Signed-off-by: Hance Wu <32484940+wzh4464@users.noreply.github.com>